### PR TITLE
Add clock="mixt" for transition-specific clocks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: hesim
 Type: Package
 Title: Health Economic Simulation Modeling and Decision Analysis
-Version: 0.5.4
+Version: 0.5.3.9000
 Authors@R: c(
     person("Devin", "Incerti", , "devin.incerti@gmail.com", role = c("aut", "cre")),
     person("Jeroen P.", "Jansen", role = "aut"),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,10 +1,11 @@
 Package: hesim
 Type: Package
 Title: Health Economic Simulation Modeling and Decision Analysis
-Version: 0.5.3
+Version: 0.5.4
 Authors@R: c(
     person("Devin", "Incerti", , "devin.incerti@gmail.com", role = c("aut", "cre")),
     person("Jeroen P.", "Jansen", role = "aut"),
+    person("Mark", "Clements", role = "aut"),
     person(given = "R Core Team", role = "ctb",
     comment="hesim uses some slightly modified C functions from base R")
     )

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+## hesim 0.5.3.900
+* For individual CTSTMs, add experimental support for `clock="mixt"` option with a `transition_types` argument for transition-specific clocks (#96).
+
 ## hesim 0.5.3
 Minor updates to the `.Rd` files to fix problems with the HTML version of the manual identified with the CRAN package checks.
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -53,8 +53,8 @@ C_cohort_dtstm_sim_stateprobs <- function(R_CohortDtstmTrans, times) {
     .Call('_hesim_C_cohort_dtstm_sim_stateprobs', PACKAGE = 'hesim', R_CohortDtstmTrans, times)
 }
 
-C_ctstm_sim_disease <- function(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, reset_transitions, max_t, max_age, progress) {
-    .Call('_hesim_C_ctstm_sim_disease', PACKAGE = 'hesim', R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, reset_transitions, max_t, max_age, progress)
+C_ctstm_sim_disease <- function(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, transition_types, max_t, max_age, progress) {
+    .Call('_hesim_C_ctstm_sim_disease', PACKAGE = 'hesim', R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, transition_types, max_t, max_age, progress)
 }
 
 C_ctstm_indiv_stateprobs <- function(R_disease_prog, t, n_samples, n_strategies, unique_strategy_id, strategy_index, n_grps, unique_grp_id, grp_index, n_states, n_patients) {

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -53,8 +53,8 @@ C_cohort_dtstm_sim_stateprobs <- function(R_CohortDtstmTrans, times) {
     .Call('_hesim_C_cohort_dtstm_sim_stateprobs', PACKAGE = 'hesim', R_CohortDtstmTrans, times)
 }
 
-C_ctstm_sim_disease <- function(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, max_t, max_age, progress) {
-    .Call('_hesim_C_ctstm_sim_disease', PACKAGE = 'hesim', R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, max_t, max_age, progress)
+C_ctstm_sim_disease <- function(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, reset_transitions, max_t, max_age, progress) {
+    .Call('_hesim_C_ctstm_sim_disease', PACKAGE = 'hesim', R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, reset_transitions, max_t, max_age, progress)
 }
 
 C_ctstm_indiv_stateprobs <- function(R_disease_prog, t, n_samples, n_strategies, unique_strategy_id, strategy_index, n_grps, unique_grp_id, grp_index, n_states, n_patients) {

--- a/R/ctstm.R
+++ b/R/ctstm.R
@@ -87,7 +87,6 @@ indiv_ctstm_sim_disease <- function(trans_model, max_t = 100, max_age = 100,
   }
   
   # Simulate
-  print(match(trans_model$transition_types, c("reset","time","age")) - 1L)
   disprog <- C_ctstm_sim_disease(trans_model, trans_model$start_state - 1, 
                                  trans_model$start_age,
                                  rep(0, trans_model$input_data$n_patients), # Start time is always 0

--- a/inst/include/hesim/ctstm/indiv-ctstm.h
+++ b/inst/include/hesim/ctstm/indiv-ctstm.h
@@ -22,8 +22,10 @@ public:
   double max_t_;
   std::string clock_;
   std::vector<int> reset_states_;
-  std::vector<int> reset_transitions_;
+  std::vector<int> transition_types_;
   double clockmix_time_;
+
+  enum TransitionType {tt_reset, tt_time, tt_age};
   
 /** 
    * The constructor.
@@ -31,7 +33,7 @@ public:
    */  
   patient(transmod * transmod, double age, double time, int state,
           double max_age, double max_t, int death_state, std::string clock,
-          std::vector<int> reset_states, std::vector<int> reset_transitions) 
+          std::vector<int> reset_states, std::vector<int> transition_types)
     : transmod_(transmod) {
     age_ = age;
     time_ = time;
@@ -41,7 +43,7 @@ public:
     death_state_ = death_state;
     clock_ = clock;
     reset_states_ = reset_states;
-    reset_transitions_ = reset_transitions;
+    transition_types_ = transition_types;
   }
   
   /** 
@@ -52,21 +54,6 @@ public:
     bool is = false;
     for (int i = 0; i < reset_states_.size(); ++i){
       if (state_ == reset_states_[i]){
-        is = true;
-        break;
-      }
-    }
-    return is;
-  }
-  
-  /** 
-   * Should model time be reset when a patient has a particular transition?
-   * @return True if a transition is a reset transition and false otherwise.
-   */    
-  bool is_reset_transition(int transition){
-    bool is = false;
-    for (int i = 0; i < reset_transitions_.size(); ++i){
-      if (transition == reset_transitions_[i]){
         is = true;
         break;
       }
@@ -93,10 +80,12 @@ public:
       } else if (clock_ == "forward"){
         random_times[i] = transmod_->trandom(trans_ids[i], sample, time_) - time_;
       } else if (clock_ == "mixt"){
-          if (is_reset_transition(trans_ids[i])){
+          if (transition_types_[trans_ids[i]] == tt_reset){
             random_times[i] = transmod_->random(trans_ids[i], sample); 
-          } else{
-           random_times[i] = transmod_->trandom(trans_ids[i], sample, time_) - time_; 
+          } else if (transition_types_[trans_ids[i]] == tt_age){
+            random_times[i] = transmod_->trandom(trans_ids[i], sample, age_) - age_;
+          } else { // transition_types_[trans_ids[i]] == tt_time
+            random_times[i] = transmod_->trandom(trans_ids[i], sample, time_) - time_;
           }
       } else { // clock == "mix" case
           if (is_reset_state()){

--- a/man/IndivCtstmTrans.Rd
+++ b/man/IndivCtstmTrans.Rd
@@ -85,16 +85,23 @@ in \code{sim_disease} as patients transition to this state upon reaching maximum
 By default, it is set to the final absorbing state (i.e., a row in \code{trans_mat} with all NAs).}
 
 \item{\code{clock}}{"reset" for a clock-reset model, "forward" for a clock-forward model,
-and "mix" for a mixture of clock-reset and clock-forward models. A clock-reset model
+"mix" for a mixture of clock-reset and clock-forward models by state, and
+"mixt" for a mixture of clock-reset and clock-forward models by transition. A clock-reset model
 is a semi-Markov model in which transition rates depend on time since entering a state.
 A clock-forward model is a Markov model in which transition rates depend on time
 since entering the initial state. If \code{"mix"} is used, then
-\code{reset_states} must be specified.}
+\code{reset_states} must be specified. If \code{"mixt"} is used, then \code{reset_transitions} must
+be specified}
 
 \item{\code{reset_states}}{A vector denoting the states in which time resets.
 Hazard functions are always a function of elapsed time since either the
 start of the model or from when time was previously reset. Only used if
 \code{clock = "mix"}.}
+
+\item{\code{reset_transitions}}{A vector denoting the transitions in which time resets.
+Hazard functions are always a function of elapsed time since either the
+start of the model or from when time was previously reset. Only used if
+\code{clock = "mixt"}.}
 }
 \if{html}{\out{</div>}}
 }
@@ -129,8 +136,9 @@ Create a new \code{IndivCtstmTrans} object.
   start_state = 1,
   start_age = 38,
   death_state = NULL,
-  clock = c("reset", "forward", "mix"),
-  reset_states = NULL
+  clock = c("reset", "forward", "mix", "mixt"),
+  reset_states = NULL,
+  reset_transitions = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -152,6 +160,8 @@ Create a new \code{IndivCtstmTrans} object.
 \item{\code{clock}}{The \code{clock} field.}
 
 \item{\code{reset_states}}{The \code{reset_states} field.}
+
+\item{\code{reset_transitions}}{The \code{reset_transitions} field.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/IndivCtstmTrans.Rd
+++ b/man/IndivCtstmTrans.Rd
@@ -90,17 +90,18 @@ By default, it is set to the final absorbing state (i.e., a row in \code{trans_m
 is a semi-Markov model in which transition rates depend on time since entering a state.
 A clock-forward model is a Markov model in which transition rates depend on time
 since entering the initial state. If \code{"mix"} is used, then
-\code{reset_states} must be specified. If \code{"mixt"} is used, then \code{reset_transitions} must
-be specified}
+\code{reset_states} must be specified. If \code{"mixt"} is used, then \code{transition_types} must
+be specified.}
 
 \item{\code{reset_states}}{A vector denoting the states in which time resets.
 Hazard functions are always a function of elapsed time since either the
 start of the model or from when time was previously reset. Only used if
 \code{clock = "mix"}.}
 
-\item{\code{reset_transitions}}{A vector denoting the transitions in which time resets.
-Hazard functions are always a function of elapsed time since either the
-start of the model or from when time was previously reset. Only used if
+\item{\code{transition_types}}{A vector denoting the type of transition.
+The vector is of the same length as the number of transitions
+and takes values \code{"reset"}, \code{"time"} or \code{"age"} for hazards that are functions of
+reset time, time since study entry or age, respectively. Only used if
 \code{clock = "mixt"}.}
 }
 \if{html}{\out{</div>}}
@@ -138,7 +139,7 @@ Create a new \code{IndivCtstmTrans} object.
   death_state = NULL,
   clock = c("reset", "forward", "mix", "mixt"),
   reset_states = NULL,
-  reset_transitions = NULL
+  transition_types = NULL
 )}\if{html}{\out{</div>}}
 }
 
@@ -161,7 +162,7 @@ Create a new \code{IndivCtstmTrans} object.
 
 \item{\code{reset_states}}{The \code{reset_states} field.}
 
-\item{\code{reset_transitions}}{The \code{reset_transitions} field.}
+\item{\code{transition_types}}{The \code{transition_types} field.}
 }
 \if{html}{\out{</div>}}
 }

--- a/man/create_IndivCtstmTrans.Rd
+++ b/man/create_IndivCtstmTrans.Rd
@@ -36,7 +36,7 @@ create_IndivCtstmTrans(object, ...)
   trans_mat,
   clock = c("reset", "forward", "mix", "mixt"),
   reset_states = NULL,
-  reset_transitions = NULL,
+  transition_types = NULL,
   ...
 )
 
@@ -46,7 +46,7 @@ create_IndivCtstmTrans(object, ...)
   trans_mat,
   clock = c("reset", "forward", "mix", "mixt"),
   reset_states = NULL,
-  reset_transitions = NULL,
+  transition_types = NULL,
   ...
 )
 }
@@ -63,7 +63,7 @@ multi-state model or parameters of a multi-state model.}
 multi-state model in the format from the \code{\link[mstate:mstate-package]{mstate}} package. See \code{\link{IndivCtstmTrans}}.}
 
 \item{clock}{"reset" for a clock-reset model, "forward" for a clock-forward model,
-"mix" for a mixture by state, and "mixt" for a mixture by transition.
+"mix" for a mixture by state, and "mixt" for a mixture by transition
 of clock-reset and clock-forward models. See the field \code{clock} in \code{\link{IndivCtstmTrans}}.}
 
 \item{n}{Number of random observations to draw. Not used if \code{uncertainty = "none"}.}
@@ -75,8 +75,8 @@ distribution. If \code{"none"}, then only point estimates are returned.}
 \item{reset_states}{A vector denoting the states in which time resets. See the field
 \code{reset_states} in \code{\link{IndivCtstmTrans}}.}
 
-\item{reset_transitions}{A vector denoting the transitions in which time resets. See the field
-\code{reset_transitions} in \code{\link{IndivCtstmTrans}}.}
+\item{transition_types}{A vector denoting the type for each transition. See the field
+\code{transition_types} in \code{\link{IndivCtstmTrans}}.}
 }
 \value{
 Returns an \code{\link{R6Class}} object of class \code{\link{IndivCtstmTrans}}.

--- a/man/create_IndivCtstmTrans.Rd
+++ b/man/create_IndivCtstmTrans.Rd
@@ -34,8 +34,9 @@ create_IndivCtstmTrans(object, ...)
   object,
   input_data,
   trans_mat,
-  clock = c("reset", "forward", "mix"),
+  clock = c("reset", "forward", "mix", "mixt"),
   reset_states = NULL,
+  reset_transitions = NULL,
   ...
 )
 
@@ -43,8 +44,9 @@ create_IndivCtstmTrans(object, ...)
   object,
   input_data,
   trans_mat,
-  clock = c("reset", "forward", "mix"),
+  clock = c("reset", "forward", "mix", "mixt"),
   reset_states = NULL,
+  reset_transitions = NULL,
   ...
 )
 }
@@ -60,7 +62,8 @@ multi-state model or parameters of a multi-state model.}
 \item{trans_mat}{The transition matrix describing the states and transitions in a
 multi-state model in the format from the \code{\link[mstate:mstate-package]{mstate}} package. See \code{\link{IndivCtstmTrans}}.}
 
-\item{clock}{"reset" for a clock-reset model, "forward" for a clock-forward model, and "mix" for a mixture
+\item{clock}{"reset" for a clock-reset model, "forward" for a clock-forward model,
+"mix" for a mixture by state, and "mixt" for a mixture by transition.
 of clock-reset and clock-forward models. See the field \code{clock} in \code{\link{IndivCtstmTrans}}.}
 
 \item{n}{Number of random observations to draw. Not used if \code{uncertainty = "none"}.}
@@ -71,6 +74,9 @@ distribution. If \code{"none"}, then only point estimates are returned.}
 
 \item{reset_states}{A vector denoting the states in which time resets. See the field
 \code{reset_states} in \code{\link{IndivCtstmTrans}}.}
+
+\item{reset_transitions}{A vector denoting the transitions in which time resets. See the field
+\code{reset_transitions} in \code{\link{IndivCtstmTrans}}.}
 }
 \value{
 Returns an \code{\link{R6Class}} object of class \code{\link{IndivCtstmTrans}}.

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -187,8 +187,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // C_ctstm_sim_disease
-Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans, std::vector<int> start_state, std::vector<double> start_age, std::vector<double> start_time, int death_state, std::string clock, std::vector<int> reset_states, std::vector<int> reset_transitions, double max_t, double max_age, int progress);
-RcppExport SEXP _hesim_C_ctstm_sim_disease(SEXP R_CtstmTransSEXP, SEXP start_stateSEXP, SEXP start_ageSEXP, SEXP start_timeSEXP, SEXP death_stateSEXP, SEXP clockSEXP, SEXP reset_statesSEXP, SEXP reset_transitionsSEXP, SEXP max_tSEXP, SEXP max_ageSEXP, SEXP progressSEXP) {
+Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans, std::vector<int> start_state, std::vector<double> start_age, std::vector<double> start_time, int death_state, std::string clock, std::vector<int> reset_states, std::vector<int> transition_types, double max_t, double max_age, int progress);
+RcppExport SEXP _hesim_C_ctstm_sim_disease(SEXP R_CtstmTransSEXP, SEXP start_stateSEXP, SEXP start_ageSEXP, SEXP start_timeSEXP, SEXP death_stateSEXP, SEXP clockSEXP, SEXP reset_statesSEXP, SEXP transition_typesSEXP, SEXP max_tSEXP, SEXP max_ageSEXP, SEXP progressSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -199,11 +199,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type death_state(death_stateSEXP);
     Rcpp::traits::input_parameter< std::string >::type clock(clockSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type reset_states(reset_statesSEXP);
-    Rcpp::traits::input_parameter< std::vector<int> >::type reset_transitions(reset_transitionsSEXP);
+    Rcpp::traits::input_parameter< std::vector<int> >::type transition_types(transition_typesSEXP);
     Rcpp::traits::input_parameter< double >::type max_t(max_tSEXP);
     Rcpp::traits::input_parameter< double >::type max_age(max_ageSEXP);
     Rcpp::traits::input_parameter< int >::type progress(progressSEXP);
-    rcpp_result_gen = Rcpp::wrap(C_ctstm_sim_disease(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, reset_transitions, max_t, max_age, progress));
+    rcpp_result_gen = Rcpp::wrap(C_ctstm_sim_disease(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, transition_types, max_t, max_age, progress));
     return rcpp_result_gen;
 END_RCPP
 }

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -187,8 +187,8 @@ BEGIN_RCPP
 END_RCPP
 }
 // C_ctstm_sim_disease
-Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans, std::vector<int> start_state, std::vector<double> start_age, std::vector<double> start_time, int death_state, std::string clock, std::vector<int> reset_states, double max_t, double max_age, int progress);
-RcppExport SEXP _hesim_C_ctstm_sim_disease(SEXP R_CtstmTransSEXP, SEXP start_stateSEXP, SEXP start_ageSEXP, SEXP start_timeSEXP, SEXP death_stateSEXP, SEXP clockSEXP, SEXP reset_statesSEXP, SEXP max_tSEXP, SEXP max_ageSEXP, SEXP progressSEXP) {
+Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans, std::vector<int> start_state, std::vector<double> start_age, std::vector<double> start_time, int death_state, std::string clock, std::vector<int> reset_states, std::vector<int> reset_transitions, double max_t, double max_age, int progress);
+RcppExport SEXP _hesim_C_ctstm_sim_disease(SEXP R_CtstmTransSEXP, SEXP start_stateSEXP, SEXP start_ageSEXP, SEXP start_timeSEXP, SEXP death_stateSEXP, SEXP clockSEXP, SEXP reset_statesSEXP, SEXP reset_transitionsSEXP, SEXP max_tSEXP, SEXP max_ageSEXP, SEXP progressSEXP) {
 BEGIN_RCPP
     Rcpp::RObject rcpp_result_gen;
     Rcpp::RNGScope rcpp_rngScope_gen;
@@ -199,10 +199,11 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< int >::type death_state(death_stateSEXP);
     Rcpp::traits::input_parameter< std::string >::type clock(clockSEXP);
     Rcpp::traits::input_parameter< std::vector<int> >::type reset_states(reset_statesSEXP);
+    Rcpp::traits::input_parameter< std::vector<int> >::type reset_transitions(reset_transitionsSEXP);
     Rcpp::traits::input_parameter< double >::type max_t(max_tSEXP);
     Rcpp::traits::input_parameter< double >::type max_age(max_ageSEXP);
     Rcpp::traits::input_parameter< int >::type progress(progressSEXP);
-    rcpp_result_gen = Rcpp::wrap(C_ctstm_sim_disease(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, max_t, max_age, progress));
+    rcpp_result_gen = Rcpp::wrap(C_ctstm_sim_disease(R_CtstmTrans, start_state, start_age, start_time, death_state, clock, reset_states, reset_transitions, max_t, max_age, progress));
     return rcpp_result_gen;
 END_RCPP
 }
@@ -656,7 +657,7 @@ static const R_CallMethodDef CallEntries[] = {
     {"_hesim_C_rdirichlet_mat", (DL_FUNC) &_hesim_C_rdirichlet_mat, 2},
     {"_hesim_C_normalize_transprobs", (DL_FUNC) &_hesim_C_normalize_transprobs, 1},
     {"_hesim_C_cohort_dtstm_sim_stateprobs", (DL_FUNC) &_hesim_C_cohort_dtstm_sim_stateprobs, 2},
-    {"_hesim_C_ctstm_sim_disease", (DL_FUNC) &_hesim_C_ctstm_sim_disease, 10},
+    {"_hesim_C_ctstm_sim_disease", (DL_FUNC) &_hesim_C_ctstm_sim_disease, 11},
     {"_hesim_C_ctstm_indiv_stateprobs", (DL_FUNC) &_hesim_C_ctstm_indiv_stateprobs, 11},
     {"_hesim_C_indiv_ctstm_wlos", (DL_FUNC) &_hesim_C_indiv_ctstm_wlos, 7},
     {"_hesim_C_indiv_ctstm_starting", (DL_FUNC) &_hesim_C_indiv_ctstm_starting, 6},

--- a/src/indiv-ctstm.cpp
+++ b/src/indiv-ctstm.cpp
@@ -24,7 +24,7 @@ Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans,
                                     int death_state,
                                     std::string clock, 
                                     std::vector<int> reset_states,
-                                    std::vector<int> reset_transitions,
+                                    std::vector<int> transition_types,
                                     double max_t, double max_age,
                                     int progress){
  
@@ -38,7 +38,7 @@ Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans,
   int n_patients = transmod->get_n_patients();
   hesim::ctstm::patient patient(transmod.get(), start_age[0], start_time[0],
                                 start_state[0], max_age, max_t, death_state, 
-                                clock, reset_states, reset_transitions); 
+                                clock, reset_states, transition_types);
   hesim::ctstm::disease_prog disease_prog;
   int N = n_samples * n_strategies * n_patients;
   disease_prog.reserve(N);

--- a/src/indiv-ctstm.cpp
+++ b/src/indiv-ctstm.cpp
@@ -24,6 +24,7 @@ Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans,
                                     int death_state,
                                     std::string clock, 
                                     std::vector<int> reset_states,
+                                    std::vector<int> reset_transitions,
                                     double max_t, double max_age,
                                     int progress){
  
@@ -37,7 +38,7 @@ Rcpp::DataFrame C_ctstm_sim_disease(Rcpp::Environment R_CtstmTrans,
   int n_patients = transmod->get_n_patients();
   hesim::ctstm::patient patient(transmod.get(), start_age[0], start_time[0],
                                 start_state[0], max_age, max_t, death_state, 
-                                clock, reset_states); 
+                                clock, reset_states, reset_transitions); 
   hesim::ctstm::disease_prog disease_prog;
   int N = n_samples * n_strategies * n_patients;
   disease_prog.reserve(N);

--- a/tests/testthat/test-ctstm.R
+++ b/tests/testthat/test-ctstm.R
@@ -614,6 +614,16 @@ test_that("IndivCtstm - joint", {
   ictstm <- IndivCtstm$new(trans_model = mstate_mix)
   disprog <- ictstm$sim_disease()$disprog_
   expect_true(is.data.table(disprog))
+
+  # Mixture
+  mstate_mix2 <- create_IndivCtstmTrans(params, input_data = msfit_data, 
+                                        trans_mat = tmat_ebmt4,
+                                        clock = "mixt",
+                                        reset_transitions = 1:max(tmat_ebmt4, na.rm=TRUE))  
+  expect_true(inherits(mstate_mix2, "IndivCtstmTrans"))
+  ictstm <- IndivCtstm$new(trans_model = mstate_mix2)
+  disprog <- ictstm$sim_disease()$disprog_
+  expect_true(is.data.table(disprog))
 })
 
 ## With fractional polynomial or survival spline from parameters object

--- a/tests/testthat/test-ctstm.R
+++ b/tests/testthat/test-ctstm.R
@@ -588,7 +588,7 @@ test_that("IndivCtstm - joint", {
   # Simulate disease progression
   expect_error(ictstm$sim_disease()$disprog_, NA)
   disprog <- ictstm$sim_disease()$disprog_
-  expect_error(ictstm$sim_disease(progress = 1), NA)
+  expect_error(ictstm$sim_disease(progress = 1), NA) # outputs sample = 1 and sample = 2
   expect_true(is.data.table(disprog))
   
   # Simulate state probabilities
@@ -604,7 +604,7 @@ test_that("IndivCtstm - joint", {
   disprog <- ictstm$sim_disease()$disprog_
   expect_true(is.data.table(disprog))
   
-  # Mixture
+  # Mixture - states
   params <- create_params(msfit, n = 2)
   msfit_data <- cbind(msfit_data, model.matrix(~factor(trans), msfit_data))
   mstate_mix <- create_IndivCtstmTrans(params, input_data = msfit_data, 
@@ -615,13 +615,29 @@ test_that("IndivCtstm - joint", {
   disprog <- ictstm$sim_disease()$disprog_
   expect_true(is.data.table(disprog))
 
-  # Mixture
-  mstate_mix2 <- create_IndivCtstmTrans(params, input_data = msfit_data, 
+  # Mixture - transitions
+  mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
                                         trans_mat = tmat_ebmt4,
                                         clock = "mixt",
-                                        transition_types = rep("r", max(tmat_ebmt4, na.rm=TRUE)))
-  expect_true(inherits(mstate_mix2, "IndivCtstmTrans"))
-  ictstm <- IndivCtstm$new(trans_model = mstate_mix2)
+                                        transition_types = rep("reset", max(tmat_ebmt4, na.rm=TRUE)))
+  expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
+  ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
+  disprog <- ictstm$sim_disease()$disprog_
+  expect_true(is.data.table(disprog))
+  mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
+                                        trans_mat = tmat_ebmt4,
+                                        clock = "mixt",
+                                        transition_types = rep("age", max(tmat_ebmt4, na.rm=TRUE)))
+  expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
+  ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
+  disprog <- ictstm$sim_disease()$disprog_
+  expect_true(is.data.table(disprog))
+  mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
+                                        trans_mat = tmat_ebmt4,
+                                        clock = "mixt",
+                                        transition_types = rep("time", max(tmat_ebmt4, na.rm=TRUE)))
+  expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
+  ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
   disprog <- ictstm$sim_disease()$disprog_
   expect_true(is.data.table(disprog))
 })

--- a/tests/testthat/test-ctstm.R
+++ b/tests/testthat/test-ctstm.R
@@ -616,30 +616,19 @@ test_that("IndivCtstm - joint", {
   expect_true(is.data.table(disprog))
 
   # Mixture - transitions
-  mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
-                                        trans_mat = tmat_ebmt4,
-                                        clock = "mixt",
-                                        transition_types = rep("reset", max(tmat_ebmt4, na.rm=TRUE)))
-  expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
-  ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
-  disprog <- ictstm$sim_disease()$disprog_
-  expect_true(is.data.table(disprog))
-  mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
-                                        trans_mat = tmat_ebmt4,
-                                        clock = "mixt",
-                                        transition_types = rep("age", max(tmat_ebmt4, na.rm=TRUE)))
-  expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
-  ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
-  disprog <- ictstm$sim_disease()$disprog_
-  expect_true(is.data.table(disprog))
-  mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
-                                        trans_mat = tmat_ebmt4,
-                                        clock = "mixt",
-                                        transition_types = rep("time", max(tmat_ebmt4, na.rm=TRUE)))
-  expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
-  ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
-  disprog <- ictstm$sim_disease()$disprog_
-  expect_true(is.data.table(disprog))
+  test_mixt <- function(trans_type) {
+    mstate_mixt <- create_IndivCtstmTrans(params, input_data = msfit_data,
+                                          trans_mat = tmat_ebmt4,
+                                          clock = "mixt",
+                                          transition_types = trans_type)
+    expect_true(inherits(mstate_mixt, "IndivCtstmTrans"))
+    ictstm <- IndivCtstm$new(trans_model = mstate_mixt)
+    disprog <- ictstm$sim_disease()$disprog_
+    expect_true(is.data.table(disprog))
+  }
+  test_mixt(rep("reset", max(tmat_ebmt4, na.rm=TRUE)))
+  test_mixt(rep("age", max(tmat_ebmt4, na.rm=TRUE)))
+  test_mixt(rep("time", max(tmat_ebmt4, na.rm=TRUE)))
 })
 
 ## With fractional polynomial or survival spline from parameters object

--- a/tests/testthat/test-ctstm.R
+++ b/tests/testthat/test-ctstm.R
@@ -619,7 +619,7 @@ test_that("IndivCtstm - joint", {
   mstate_mix2 <- create_IndivCtstmTrans(params, input_data = msfit_data, 
                                         trans_mat = tmat_ebmt4,
                                         clock = "mixt",
-                                        reset_transitions = 1:max(tmat_ebmt4, na.rm=TRUE))  
+                                        transition_types = rep("r", max(tmat_ebmt4, na.rm=TRUE)))
   expect_true(inherits(mstate_mix2, "IndivCtstmTrans"))
   ictstm <- IndivCtstm$new(trans_model = mstate_mix2)
   disprog <- ictstm$sim_disease()$disprog_


### PR DESCRIPTION
Devin,

As a follow-up to https://github.com/hesim-dev/hesim/issues/96, the following pull request adds a `clock="mixt"` argument for transition-specific clocks in the individual-based CTSTMs. This includes a new argument `reset_transitions` to the `IndivCtstmTrans` class, which is similar to the `reset_states` argument. I have also included some simple tests.

An important use case is that a state has an age-related transition to other causes of death (e.g. using a piecewise-constant exponential hazard) and an excess mortality related to time in state (e.g. using cause-specific survival).

Sincerely, Mark.